### PR TITLE
Add pre-draft Fantasy sport

### DIFF
--- a/src/components/SiteLayout.tsx
+++ b/src/components/SiteLayout.tsx
@@ -15,14 +15,16 @@ const YEAR_OPTIONS: Record<Sport, string[]> = {
   nba: ["2025", "2024"],
   nfl: ["2025", "2024"],
   wnba: ["2026"],
+  fantasy: ["2026"],
 };
 
-const SPORT_OPTIONS: Sport[] = ["mlb", "nba", "nfl", "wnba"];
+const SPORT_OPTIONS: Sport[] = ["mlb", "nba", "nfl", "wnba", "fantasy"];
 
 export default function SiteLayout() {
   const initialSport = defaultSport();
   const [sport, setSport] = useState<Sport>(initialSport);
   const [year, setYear] = useState(YEAR_OPTIONS[initialSport][0]);
+  const isFantasy = sport === "fantasy";
 
   useEffect(() => {
     setYear(YEAR_OPTIONS[sport][0]);
@@ -30,22 +32,33 @@ export default function SiteLayout() {
 
   return (
     <div className="w-full">
-      <Toggle item={sport} options={SPORT_OPTIONS} setItem={setSport} />
-      <LastUpdated sport={sport} />
       <Toggle
-        item={year}
-        options={YEAR_OPTIONS[sport]}
-        setItem={setYear}
+        item={sport}
+        options={SPORT_OPTIONS}
+        setItem={setSport}
+        labels={{ fantasy: "Fantasy" }}
       />
-      <h2 className="my-3 text-xl font-semibold sm:text-2xl">
-        Current Standings
-      </h2>
-      <CurrentStandings sport={sport} year={parseInt(year, 10)} />
-      <h2 className="my-3 text-xl font-semibold sm:text-2xl">Head to Head</h2>
-      <HeadToHead sport={sport} year={parseInt(year, 10)} />
+      {!isFantasy && <LastUpdated sport={sport} />}
+      {!isFantasy && (
+        <Toggle
+          item={year}
+          options={YEAR_OPTIONS[sport]}
+          setItem={setYear}
+        />
+      )}
+      {!isFantasy && (
+        <>
+          <h2 className="my-3 text-xl font-semibold sm:text-2xl">
+            Current Standings
+          </h2>
+          <CurrentStandings sport={sport} year={parseInt(year, 10)} />
+          <h2 className="my-3 text-xl font-semibold sm:text-2xl">Head to Head</h2>
+          <HeadToHead sport={sport} year={parseInt(year, 10)} />
+        </>
+      )}
       <h2 className="my-3 text-xl font-semibold sm:text-2xl">Full Draft</h2>
       <FullDraft sport={sport} year={parseInt(year, 10)} />
-      <HowTo />
+      {!isFantasy && <HowTo />}
     </div>
   );
 }

--- a/src/components/content/CurrentStandings.tsx
+++ b/src/components/content/CurrentStandings.tsx
@@ -1,8 +1,9 @@
 import { useLayoutEffect, useState, type CSSProperties } from "react";
 import { usePoolData } from "../../PoolDataContext";
-import { handleSort, imgPath } from "../../utils";
+import { handleSort } from "../../utils";
 import type { H2HRow, SortedState, Sport, StandingRow } from "../../types";
 import SortChips, { type SortChipOption } from "../utility/SortChips";
+import TeamMark from "../utility/TeamMark";
 
 /** Fixed logo slot size in px (desktop). Logos are contained within this box. */
 const LOGO_FULL_SIZE = 68;
@@ -113,7 +114,11 @@ export default function CurrentStandings({ sport, year }: CurrentStandingsProps)
       logoScaleByAbbrev: scales,
       formWindow: windowSize,
       maxTeams: teamCols,
-    } = buildStandings(year, payload[`${sport}_standings`], payload[`${sport}_h2h`]);
+    } = buildStandings(
+      year,
+      payload[`${sport}_standings`] || [],
+      payload[`${sport}_h2h`] || [],
+    );
 
     setData(rows);
     setLogoScaleByAbbrev(scales);
@@ -247,8 +252,9 @@ export default function CurrentStandings({ sport, year }: CurrentStandingsProps)
                         key={idx}
                         className="flex h-full min-h-0 min-w-0 w-full items-center justify-center overflow-hidden"
                       >
-                        <img
-                          src={imgPath(sport, abbrev)}
+                        <TeamMark
+                          sport={sport}
+                          abbrev={abbrev}
                           alt={abbrev + " Logo"}
                           className="max-h-full max-w-full object-contain p-0.5"
                           style={{

--- a/src/components/content/FullDraft.tsx
+++ b/src/components/content/FullDraft.tsx
@@ -1,8 +1,9 @@
 import { useLayoutEffect, useState } from "react";
 import { usePoolData } from "../../PoolDataContext";
-import { handleSort, imgPath, teamNickname } from "../../utils";
+import { handleSort, teamNickname } from "../../utils";
 import type { H2HRow, SortedState, Sport, StandingRow } from "../../types";
 import SortChips, { type SortChipOption } from "../utility/SortChips";
+import TeamMark from "../utility/TeamMark";
 
 type FullDraftProps = {
   sport: Sport;
@@ -78,7 +79,11 @@ export default function FullDraft({ sport, year }: FullDraftProps) {
       payload[`${sport}_standings`] || [],
       payload[`${sport}_h2h`] || [],
     );
-    setData(rows);
+    const nextRows =
+      sport === "fantasy"
+        ? rows.map((row) => ({ ...row, nickname: String(row.team) }))
+        : rows;
+    setData(nextRows);
     setFormWindow(windowSize);
     setExpandedRows(
       Object.fromEntries(rows.map((row) => [row.abbrev, false])),
@@ -97,17 +102,24 @@ export default function FullDraft({ sport, year }: FullDraftProps) {
     return <p className="my-1 px-4 text-sm sm:text-base">Loading..</p>;
   }
 
+  const isFantasy = sport === "fantasy";
   const formLabelShort = formWindow != null ? `L${formWindow}` : "Form";
   const formLabelLong =
     formWindow != null ? `Last ${formWindow}` : "Form";
 
-  const draftSortChips: SortChipOption[] = [
-    { key: "pick_int", label: "Pick", natural: "asc" },
-    { key: "pct", label: "Record", natural: "desc" },
-    { key: "recent_wins", label: formLabelShort, natural: "desc" },
-    { key: "nickname", label: "Team", natural: "asc" },
-    { key: "owner", label: "Owner", natural: "asc" },
-  ];
+  const draftSortChips: SortChipOption[] = isFantasy
+    ? [
+        { key: "pick_int", label: "Pick", natural: "asc" },
+        { key: "nickname", label: "Team", natural: "asc" },
+        { key: "owner", label: "Owner", natural: "asc" },
+      ]
+    : [
+        { key: "pick_int", label: "Pick", natural: "asc" },
+        { key: "pct", label: "Record", natural: "desc" },
+        { key: "recent_wins", label: formLabelShort, natural: "desc" },
+        { key: "nickname", label: "Team", natural: "asc" },
+        { key: "owner", label: "Owner", natural: "asc" },
+      ];
 
   return (
     <div className="w-full">
@@ -177,45 +189,49 @@ export default function FullDraft({ sport, year }: FullDraftProps) {
               >
                 Owner
               </th>
-              <th
-                className="cursor-pointer px-1"
-                onClick={() =>
-                  handleSort(
-                    "pct",
-                    sorted,
-                    setSorted,
-                    data,
-                    setData,
-                    "desc",
-                    setExpandedRows,
-                    "nickname",
-                  )
-                }
-              >
-                Record
-              </th>
-              <th
-                className="cursor-pointer px-1"
-                onClick={() =>
-                  handleSort(
-                    "recent_wins",
-                    sorted,
-                    setSorted,
-                    data,
-                    setData,
-                    "desc",
-                    setExpandedRows,
-                    "nickname",
-                  )
-                }
-                title={
-                  formWindow != null
-                    ? `Record over each team's last ${formWindow} games`
-                    : "Recent form"
-                }
-              >
-                {formLabelLong}
-              </th>
+              {!isFantasy && (
+                <th
+                  className="cursor-pointer px-1"
+                  onClick={() =>
+                    handleSort(
+                      "pct",
+                      sorted,
+                      setSorted,
+                      data,
+                      setData,
+                      "desc",
+                      setExpandedRows,
+                      "nickname",
+                    )
+                  }
+                >
+                  Record
+                </th>
+              )}
+              {!isFantasy && (
+                <th
+                  className="cursor-pointer px-1"
+                  onClick={() =>
+                    handleSort(
+                      "recent_wins",
+                      sorted,
+                      setSorted,
+                      data,
+                      setData,
+                      "desc",
+                      setExpandedRows,
+                      "nickname",
+                    )
+                  }
+                  title={
+                    formWindow != null
+                      ? `Record over each team's last ${formWindow} games`
+                      : "Recent form"
+                  }
+                >
+                  {formLabelLong}
+                </th>
+              )}
             </tr>
           </thead>
           {data.map((row) => {
@@ -225,28 +241,43 @@ export default function FullDraft({ sport, year }: FullDraftProps) {
             return (
               <tbody key={row.abbrev} className="bg-white">
                 <tr
-                  className="draft-main group cursor-pointer bg-white transition-colors hover:bg-neutral-100 max-md:grid max-md:w-full max-md:grid-cols-[auto_1fr_auto_auto] max-md:grid-rows-[auto_auto] max-md:items-center max-md:gap-x-2 max-md:gap-y-0.5 max-md:px-2.5 max-md:py-2"
-                  role="button"
-                  tabIndex={0}
-                  aria-expanded={isExpanded}
-                  aria-label={`${isExpanded ? "Collapse" : "Expand"} details for ${row.team}`}
-                  onClick={toggle}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === " ") {
-                      event.preventDefault();
-                      toggle();
-                    }
-                  }}
+                  className={
+                    isFantasy
+                      ? "draft-main bg-white max-md:grid max-md:w-full max-md:grid-cols-[auto_1fr_auto] max-md:grid-rows-[auto_auto] max-md:items-center max-md:gap-x-2 max-md:gap-y-0.5 max-md:px-2.5 max-md:py-2"
+                      : "draft-main group cursor-pointer bg-white transition-colors hover:bg-neutral-100 max-md:grid max-md:w-full max-md:grid-cols-[auto_1fr_auto_auto] max-md:grid-rows-[auto_auto] max-md:items-center max-md:gap-x-2 max-md:gap-y-0.5 max-md:px-2.5 max-md:py-2"
+                  }
+                  role={isFantasy ? undefined : "button"}
+                  tabIndex={isFantasy ? undefined : 0}
+                  aria-expanded={isFantasy ? undefined : isExpanded}
+                  aria-label={
+                    isFantasy
+                      ? undefined
+                      : `${isExpanded ? "Collapse" : "Expand"} details for ${row.team}`
+                  }
+                  onClick={isFantasy ? undefined : toggle}
+                  onKeyDown={
+                    isFantasy
+                      ? undefined
+                      : (event) => {
+                          if (event.key === "Enter" || event.key === " ") {
+                            event.preventDefault();
+                            toggle();
+                          }
+                        }
+                  }
                 >
                   <td className="max-md:col-start-1 max-md:row-span-2 max-md:row-start-1 max-md:border-none max-md:p-0">
-                    <img
+                    <TeamMark
+                      sport={sport}
+                      abbrev={row.abbrev}
+                      alt={row.team}
                       className="mx-auto w-[min(2.75rem,8vw)] p-1 max-md:mx-0 max-md:w-10 max-md:p-0"
-                      src={imgPath(sport, row.abbrev)}
-                      alt={row.abbrev + " Logo"}
                     />
                   </td>
                   <td className="text-[min(1rem,3.5vw)] group-hover:underline decoration-black underline-offset-2 max-md:col-start-2 max-md:row-start-1 max-md:border-none max-md:p-0 max-md:text-left max-md:text-base max-md:font-semibold max-md:no-underline">
-                    <span className="md:hidden">{row.nickname}</span>
+                    <span className="md:hidden">
+                      {isFantasy ? row.team : row.nickname}
+                    </span>
                     <span className="max-md:hidden">{row.team}</span>
                   </td>
                   <td className="max-md:col-start-3 max-md:row-start-1 max-md:border-none max-md:p-0">
@@ -259,26 +290,30 @@ export default function FullDraft({ sport, year }: FullDraftProps) {
                   <td className="text-[min(1rem,3.5vw)] max-md:col-start-2 max-md:row-start-2 max-md:border-none max-md:p-0 max-md:text-left max-md:text-sm max-md:text-neutral-600">
                     {row.owner}
                   </td>
-                  <td className="max-md:col-start-4 max-md:row-start-1 max-md:border-none max-md:p-0">
-                    <span className="max-md:hidden">{String(row.record ?? "")}</span>
-                    <div className="hidden max-md:flex flex-col items-center justify-center leading-snug">
-                      <span className="text-base">{String(row.record ?? "")}</span>
-                      <span className="-mt-0.5 text-[0.6em]">Record</span>
-                    </div>
-                  </td>
-                  <td className="max-md:col-start-3 max-md:col-span-2 max-md:row-start-2 max-md:border-none max-md:p-0 max-md:text-right max-md:text-sm max-md:text-neutral-600">
-                    <span className="max-md:hidden">{row.recent_record}</span>
-                    <span className="hidden max-md:inline">
-                      {formLabelShort}: {row.recent_record}
-                      {row.recent_n > 0 &&
-                      formWindow != null &&
-                      row.recent_n < formWindow
-                        ? ` (${row.recent_n} gms)`
-                        : ""}
-                    </span>
-                  </td>
+                  {!isFantasy && (
+                    <td className="max-md:col-start-4 max-md:row-start-1 max-md:border-none max-md:p-0">
+                      <span className="max-md:hidden">{String(row.record ?? "")}</span>
+                      <div className="hidden max-md:flex flex-col items-center justify-center leading-snug">
+                        <span className="text-base">{String(row.record ?? "")}</span>
+                        <span className="-mt-0.5 text-[0.6em]">Record</span>
+                      </div>
+                    </td>
+                  )}
+                  {!isFantasy && (
+                    <td className="max-md:col-start-3 max-md:col-span-2 max-md:row-start-2 max-md:border-none max-md:p-0 max-md:text-right max-md:text-sm max-md:text-neutral-600">
+                      <span className="max-md:hidden">{row.recent_record}</span>
+                      <span className="hidden max-md:inline">
+                        {formLabelShort}: {row.recent_record}
+                        {row.recent_n > 0 &&
+                        formWindow != null &&
+                        row.recent_n < formWindow
+                          ? ` (${row.recent_n} gms)`
+                          : ""}
+                      </span>
+                    </td>
+                  )}
                 </tr>
-                {isExpanded && (
+                {!isFantasy && isExpanded && (
                   <tr className="draft-detail bg-white">
                     <td
                       colSpan={6}

--- a/src/components/content/HeadToHead.tsx
+++ b/src/components/content/HeadToHead.tsx
@@ -7,8 +7,9 @@ import {
   type SetStateAction,
 } from "react";
 import { usePoolData } from "../../PoolDataContext";
-import { handleSort, imgPath } from "../../utils";
+import { handleSort } from "../../utils";
 import type { H2HRow, SortedState, Sport } from "../../types";
+import TeamMark from "../utility/TeamMark";
 
 type OwnerH2HRow = {
   owner: string;
@@ -259,8 +260,9 @@ export default function HeadToHead({ sport, year }: HeadToHeadProps) {
                           .map((team, i) => (
                             <tr key={i} className="bg-white">
                               <td className="whitespace-nowrap">
-                                <img
-                                  src={imgPath(sport, team.abbrev ?? "")}
+                                <TeamMark
+                                  sport={sport}
+                                  abbrev={team.abbrev ?? ""}
                                   alt={`${team.abbrev} Logo`}
                                   className="mx-auto w-[min(2.75rem,8vw)] p-1"
                                 />

--- a/src/components/utility/TeamMark.tsx
+++ b/src/components/utility/TeamMark.tsx
@@ -1,0 +1,58 @@
+import type { CSSProperties } from "react";
+import type { Sport } from "../../types";
+import { imgPath } from "../../utils";
+
+type TeamMarkProps = {
+  sport: Sport;
+  abbrev: string;
+  alt?: string;
+  className?: string;
+  style?: CSSProperties;
+};
+
+const FANTASY_COLORS: Record<string, string> = {
+  KR: "#2563eb",
+  RS: "#d97706",
+  AM: "#059669",
+  RD: "#7c3aed",
+  NF: "#e11d48",
+  SW: "#0d9488",
+  SS: "#ea580c",
+  AF: "#4f46e5",
+  RG: "#c026d3",
+  RW: "#0891b2",
+  DI: "#65a30d",
+  LN: "#dc2626",
+};
+
+export default function TeamMark({
+  sport,
+  abbrev,
+  alt,
+  className,
+  style,
+}: TeamMarkProps) {
+  const label = alt ?? `${abbrev} Logo`;
+
+  if (sport === "fantasy") {
+    const backgroundColor = FANTASY_COLORS[abbrev] ?? "#525252";
+    return (
+      <span
+        role="img"
+        aria-label={label}
+        title={abbrev}
+        className={`flex aspect-square items-center justify-center rounded-full text-[0.65rem] font-semibold tracking-tight text-white ${className ?? ""}`}
+        style={{
+          backgroundColor,
+          ...style,
+        }}
+      >
+        {abbrev}
+      </span>
+    );
+  }
+
+  return (
+    <img src={imgPath(sport, abbrev)} alt={label} className={className} style={style} />
+  );
+}

--- a/src/components/utility/Toggle.tsx
+++ b/src/components/utility/Toggle.tsx
@@ -5,12 +5,14 @@ type ToggleProps<T extends string> = {
   item: T;
   options: readonly T[];
   setItem: (value: T) => void;
+  labels?: Partial<Record<T, string>>;
 };
 
 export default function Toggle<T extends string>({
   item,
   options,
   setItem,
+  labels,
 }: ToggleProps<T>) {
   const handleChange = (_: unknown, newValue: T | null) => {
     if (newValue != null) {
@@ -28,7 +30,7 @@ export default function Toggle<T extends string>({
       >
         {options.map((option) => (
           <ToggleButton key={option} value={option}>
-            {option.toUpperCase()}
+            {labels?.[option] ?? option.toUpperCase()}
           </ToggleButton>
         ))}
       </ToggleButtonGroup>

--- a/src/data/fantasy.ts
+++ b/src/data/fantasy.ts
@@ -1,0 +1,67 @@
+import type { H2HRow, StandingRow } from "../types";
+
+function initials(name: string): string {
+  return name
+    .split(/\s+/)
+    .map((part) => part[0] ?? "")
+    .join("")
+    .toUpperCase();
+}
+
+const FANTASY_TEAMS = [
+  { pick: 1, owner: "Noah", team: "Keshav Rangan" },
+  { pick: 2, owner: "Rikhav", team: "Rikhav Shah" },
+  { pick: 3, owner: "Keshav", team: "Ajay Manickam" },
+  { pick: 4, owner: "Ajay", team: "Rohith Divi" },
+  { pick: 5, owner: "Ajay", team: "Noah Ford" },
+  { pick: 6, owner: "Keshav", team: "Sam Warren" },
+  { pick: 7, owner: "Rikhav", team: "Stephen Starr" },
+  { pick: 8, owner: "Noah", team: "Alex Frederick" },
+  { pick: 9, owner: "Ajay", team: "Rohit Gandhari" },
+  { pick: 10, owner: "Keshav", team: "Raymond Wheeler" },
+  { pick: 11, owner: "Rikhav", team: "Dean Izzo" },
+  { pick: 12, owner: "Noah", team: "Liam Nelson" },
+].map((row) => ({ ...row, abbrev: initials(row.team) }));
+
+const ZERO_VS = {
+  vs_ajay: "0-0",
+  vs_keshav: "0-0",
+  vs_noah: "0-0",
+  vs_rikhav: "0-0",
+} as const;
+
+const OWNERS = ["Ajay", "Keshav", "Noah", "Rikhav"] as const;
+
+export const FANTASY_STANDINGS: StandingRow[] = FANTASY_TEAMS.map((row) => ({
+  year: 2026,
+  pick: row.pick,
+  pick_int: row.pick,
+  owner: row.owner,
+  team: row.team,
+  abbrev: row.abbrev,
+  wins: 0,
+  games: 0,
+  record: "0-0",
+  pct: 0,
+  logo_scale: 1,
+  ou: "—",
+  wins_exp: "—",
+  wins_pace: "—",
+}));
+
+export const FANTASY_H2H: H2HRow[] = [
+  ...OWNERS.map((owner) => ({
+    year: 2026,
+    owner,
+    role: "owner" as const,
+    abbrev: owner,
+    ...ZERO_VS,
+  })),
+  ...FANTASY_TEAMS.map((row) => ({
+    year: 2026,
+    owner: row.owner,
+    role: "team" as const,
+    abbrev: row.abbrev,
+    ...ZERO_VS,
+  })),
+];

--- a/src/poolData.ts
+++ b/src/poolData.ts
@@ -1,22 +1,47 @@
+import { FANTASY_H2H, FANTASY_STANDINGS } from "./data/fantasy";
 import type { PoolDataPayload } from "./types";
 
 let cached: PoolDataPayload | null = null;
 let inflight: Promise<PoolDataPayload> | null = null;
 
+function withFantasy(payload: Partial<PoolDataPayload> = {}): PoolDataPayload {
+  return {
+    nfl_standings: payload.nfl_standings ?? [],
+    nfl_h2h: payload.nfl_h2h ?? [],
+    nba_standings: payload.nba_standings ?? [],
+    nba_h2h: payload.nba_h2h ?? [],
+    mlb_standings: payload.mlb_standings ?? [],
+    mlb_h2h: payload.mlb_h2h ?? [],
+    wnba_standings: payload.wnba_standings ?? [],
+    wnba_h2h: payload.wnba_h2h ?? [],
+    updated: payload.updated ?? [],
+    fantasy_standings: FANTASY_STANDINGS,
+    fantasy_h2h: FANTASY_H2H,
+  };
+}
+
+async function fetchRemotePayload(): Promise<Partial<PoolDataPayload>> {
+  const response = await fetch("/api/pool-data");
+  const contentType = response.headers.get("content-type") ?? "";
+  if (!response.ok || !contentType.includes("application/json")) {
+    throw new Error(`Failed to fetch pool data (${response.status})`);
+  }
+  return (await response.json()) as PoolDataPayload;
+}
+
 export async function fetchPoolData(): Promise<PoolDataPayload> {
   if (cached) return cached;
   if (inflight) return inflight;
 
-  inflight = fetch("api/pool-data")
-    .then(async (response) => {
-      if (!response.ok) {
-        throw new Error(`Failed to fetch pool data (${response.status})`);
-      }
-      return (await response.json()) as PoolDataPayload;
+  inflight = fetchRemotePayload()
+    .then((payload) => withFantasy(payload))
+    .catch((err: unknown) => {
+      console.error("Error fetching pool data:", err);
+      return withFantasy();
     })
     .then((payload) => {
       cached = payload;
-      return payload;
+      return cached;
     })
     .finally(() => {
       inflight = null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type Sport = "mlb" | "nba" | "nfl" | "wnba";
+export type Sport = "mlb" | "nba" | "nfl" | "wnba" | "fantasy";
 
 export type SortDir = "asc" | "desc";
 
@@ -51,5 +51,7 @@ export type PoolDataPayload = {
   mlb_h2h: H2HRow[];
   wnba_standings: StandingRow[];
   wnba_h2h: H2HRow[];
+  fantasy_standings: StandingRow[];
+  fantasy_h2h: H2HRow[];
   updated: UpdateTimeRow[];
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,67 @@
-import { defineConfig } from "vite";
+import { defineConfig, type Plugin } from "vite";
 import react from "@vitejs/plugin-react";
 import vercel from "vite-plugin-vercel";
 import tailwindcss from "@tailwindcss/vite";
+import type { IncomingMessage } from "node:http";
 
-// https://vite.dev/config/
+type VercelRes = {
+  status: (code: number) => VercelRes;
+  setHeader: (key: string, value: string) => VercelRes;
+  json: (body: unknown) => void;
+};
+
+function vercelApiDev(): Plugin {
+  return {
+    name: "vercel-api-dev",
+    configureServer(server) {
+      server.middlewares.use(async (req, res, next) => {
+        const url = req.url?.split("?")[0];
+        if (url !== "/api/pool-data") {
+          next();
+          return;
+        }
+
+        try {
+          const mod = await server.ssrLoadModule("/api/pool-data.js");
+          const handler = mod.default as (
+            request: IncomingMessage,
+            response: VercelRes,
+          ) => Promise<void>;
+
+          let statusCode = 200;
+          const apiRes: VercelRes = {
+            status(code: number) {
+              statusCode = code;
+              return this;
+            },
+            setHeader(key: string, value: string) {
+              res.setHeader(key, value);
+              return this;
+            },
+            json(body: unknown) {
+              res.statusCode = statusCode;
+              res.setHeader("Content-Type", "application/json");
+              res.end(JSON.stringify(body));
+            },
+          };
+
+          await handler(req, apiRes);
+        } catch (err) {
+          res.statusCode = 500;
+          res.setHeader("Content-Type", "application/json");
+          res.end(
+            JSON.stringify({
+              error:
+                err instanceof Error ? err.message : "Internal Server Error",
+            }),
+          );
+        }
+      });
+    },
+  };
+}
+
 export default defineConfig({
-  plugins: [react(), vercel(), tailwindcss()],
+  plugins: [vercelApiDev(), react(), vercel(), tailwindcss()],
   vercel: {},
 });


### PR DESCRIPTION
## Summary
- Add a Fantasy sport toggle that shows the 2026 ESPN league draft (12 managers, initials badges from full names).
- Keep standings and head-to-head hidden for Fantasy until games exist; merge static draft data on the client so no new Supabase tables are required.
- Run `/api/pool-data` in Vite so MLB/NBA/NFL/WNBA still load locally.

## Test plan
- [ ] Open the dashboard locally and confirm MLB/NBA/NFL/WNBA still show live standings, H2H, and drafts.
- [ ] Switch to Fantasy and confirm only Full Draft appears, labeled **Fantasy**.
- [ ] Confirm the 12 picks match the draft (Noah/Rikhav/Keshav/Ajay) with full names and initials (KR, RS, AM, …).
- [ ] Confirm Keshav Rangan and Rikhav Shah appear (not the ESPN aliases).


Made with [Cursor](https://cursor.com)